### PR TITLE
Remove lack of Delayed Procedure Call

### DIFF
--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -8,6 +8,7 @@
 // SS_TICKER
 #define SS_PRIORITY_OVERLAY      100  // Applies overlays. May cause overlay pop-in if it gets behind.
 #define SS_PRIORITY_TIMER         20
+#define SS_PRIORITY_DPC           19 //SS220 ADD
 
 // Normal
 #define SS_PRIORITY_TICKER       100  // Gameticker.

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -8,7 +8,7 @@
 // SS_TICKER
 #define SS_PRIORITY_OVERLAY      100  // Applies overlays. May cause overlay pop-in if it gets behind.
 #define SS_PRIORITY_TIMER         20
-#define SS_PRIORITY_DPC           19 //SS220 ADD
+#define SS_PRIORITY_DPC           19  //SS220 ADD
 
 // Normal
 #define SS_PRIORITY_TICKER       100  // Gameticker.

--- a/code/controllers/subsystems/dpc.dm
+++ b/code/controllers/subsystems/dpc.dm
@@ -1,0 +1,37 @@
+/*
+This is pretty much just an optimization for wait=0 timers. They're relatively common, but generally don't actually need the more
+ complex features of SStimer. SSdpc can handle these timers instead (and it's a lot simpler than SStimer is), but it can't handle
+ complex timers with flags. This doesn't need to be explicitly used, eligible timers are automatically converted.
+*/
+
+SUBSYSTEM_DEF(dpc)
+	name = "Delayed Procedure Call"
+	wait = 1
+	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	priority = SS_PRIORITY_DPC
+	flags = SS_TICKER | SS_NO_INIT
+
+	var/list/queued_calls = list()
+	var/list/avg = 0
+
+/datum/controller/subsystem/dpc/stat_entry()
+	return ..() + " Q: [queued_calls.len], AQ: ~[round(avg)]"
+
+/datum/controller/subsystem/dpc/fire(resumed = FALSE)
+	var/list/qc = queued_calls
+	if (!resumed)
+		avg = MC_AVERAGE_FAST(avg, qc.len)
+
+	var/q_idex = 1
+
+	while (q_idex <= qc.len)
+		var/datum/callback/CB = qc[q_idex]
+		q_idex += 1
+
+		CB.InvokeAsync()
+
+		if (MC_TICK_CHECK)
+			break
+
+	if (q_idex > 1)
+		queued_calls.Cut(1, q_idex)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -569,6 +569,12 @@ SUBSYSTEM_DEF(timer)
 		PRINT_STACK_TRACE("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not \
 			be supported and may refuse to run or run with a 0 wait")
 
+	// SS220 ADD BEGIN
+	if (wait == 0 && !flags)
+		SSdpc.queued_calls += callback
+		return
+	// SS220 ADD END
+
 	wait = max(NONUNIT_CEILING(wait, world.tick_lag), world.tick_lag)
 
 	if(wait >= INFINITY)

--- a/nebula.dme
+++ b/nebula.dme
@@ -261,6 +261,7 @@
 #include "code\controllers\subsystems\configuration.dm"
 #include "code\controllers\subsystems\daycycle.dm"
 #include "code\controllers\subsystems\disposals.dm"
+#include "code\controllers\subsystems\dpc.dm"
 #include "code\controllers\subsystems\evac.dm"
 #include "code\controllers\subsystems\event.dm"
 #include "code\controllers\subsystems\fluids.dm"


### PR DESCRIPTION
Украл у out-of-phaze DPC, который он взял с CitadelRP. Оптимизация wait=0 таймеров. Nuff said. 